### PR TITLE
Improve working-with-c-cpp-python-in-visual-studio.md

### DIFF
--- a/docs/python/working-with-c-cpp-python-in-visual-studio.md
+++ b/docs/python/working-with-c-cpp-python-in-visual-studio.md
@@ -118,7 +118,7 @@ Follow the instructions in this section to create two identical C++ projects nam
     | Tab | Property | Value |
     | --- | --- | --- |
     | **General** | **General** > **Target Name** | Specify the name of the module as you want to refer to it from Python in `from...import` statements. You use this same name in the C++ when defining the module for Python. If you want to use the name of the project as the module name, leave the default value of **$(ProjectName)**. |
-    | | **General** > **Target Extension** | **.pyd** |
+    | | **Advanced** > **Target File Extension** | **.pyd** |
     | | **Project Defaults** > **Configuration Type** | **Dynamic Library (.dll)** |
     | **C/C++** > **General** | **Additional Include Directories** | Add the Python *include* folder as appropriate for your installation, for example, `c:\Python36\include`.  |
     | **C/C++** > **Preprocessor** | **Preprocessor Definitions** | **CPython only**: add `Py_LIMITED_API;` to the beginning of the string (including the semicolon). This definition restricts some of the functions you can call from Python and makes the code more portable between different versions of Python. If you're working with PyBind11, don't add this definition, otherwise you'll see build errors. |


### PR DESCRIPTION
The `working-with-c-cpp-python-in-visual-studio` docs states that we have to use the property **General** -> **General** -> **Target Extension** to set the file extension to `.pyd`. But in Visual Studio 2019 we have to use the property  **General** -> **Advanced** -> **Target File Extension** to set the file extension to `.pyd`. This PR just updates that.